### PR TITLE
bump heroku-cli-command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Jeff Dickey @jdxcode",
   "bugs": "https://github.com/oclif/plugin-legacy/issues",
   "dependencies": {
-    "@heroku-cli/command": "^8.2.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/color": "^0.0.0",
     "@oclif/command": "^1.5.4",
     "ansi-escapes": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,26 @@
     supports-color "^5.5.0"
     tslib "^1.9.3"
 
-"@heroku-cli/command@^8.2.0", "@heroku-cli/command@^8.4.0":
+"@heroku-cli/command@^8.4.0":
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.4.0.tgz#3f977eeadfb3aacbe79172644f1fee8040893cae"
   integrity sha512-TN4v5VYIJeLizhNBwP3bDKrUQLdriGVSDRT55/Il2Dyg9i8hkoUQURckcGv0H/MS2oissqCGXfNzNZu2VRbC2Q==
+  dependencies:
+    "@heroku-cli/color" "^1.1.14"
+    "@oclif/errors" "^1.2.2"
+    cli-ux "^4.9.3"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    heroku-client "^3.1.0"
+    http-call "^5.2.4"
+    netrc-parser "^3.1.6"
+    open "^6.2.0"
+    uuid "^8.3.0"
+
+"@heroku-cli/command@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.4.1.tgz#7efe7f7f2a368369108f12540760fe67405a517c"
+  integrity sha512-B8Jg0FtlxNnkRYepzMcAsq17uTxQlg8NubiQKKtlertJmvBUJ2QoBczhsHCc4wuXSlraVhTgRnfT77fZ8bqROw==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@oclif/errors" "^1.2.2"


### PR DESCRIPTION
This PR brings the version of `@heroku-cli/command` up to date.